### PR TITLE
Updates to allow newer versions of the aws provider

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
           command: if [ `terraform fmt | wc -c` -ne 0 ]; then echo "Some terraform files need be formatted, run 'terraform fmt' to fix"; exit 1; fi
       - run:
           name: "get tflint"
-          command: apk add wget ; wget https://github.com/wata727/tflint/releases/download/v0.4.2/tflint_linux_amd64.zip ; unzip tflint_linux_amd64.zip
+          command: apk update && apk add wget ; wget https://github.com/wata727/tflint/releases/download/v0.5.4/tflint_linux_amd64.zip ; unzip tflint_linux_amd64.zip
       - run:
           name: "install tflint"
           command: mkdir -p /usr/local/tflint/bin ; export PATH=/usr/local/tflint/bin:$PATH ; install tflint /usr/local/tflint/bin

--- a/files/vault.json
+++ b/files/vault.json
@@ -2,11 +2,14 @@
         {
             "name": "vault-${env}",
             "image": "${image}",
+            "essential": true,
             "memoryReservation": 10,
             "privileged": true,
             "portMappings": [
                 {
-                    "containerPort": 8200
+                    "containerPort": 8200,
+                    "hostPort": 8200,
+                    "protocol": "tcp"
                 }
             ],
             "environment": [
@@ -17,6 +20,13 @@
             ],
             "command": [
               "server"
+            ],
+            "cpu": 0,
+            "volumesFrom": [
+              
+            ],
+            "mountPoints": [
+
             ],
             "logConfiguration": {
               "logDriver": "awslogs",


### PR DESCRIPTION
This allows us to use the newer aws providers without cycling the ECS
tasks for vault over and over again.