### PR TITLE
fix suffix trimming

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -13,7 +13,7 @@ data "aws_route53_zone" "zone" {
 
 data "aws_acm_certificate" "cert" {
   count       = local.enable_custom_domain ? 1 : 0
-  domain      = replace(var.dns_zone, "/.$/", "") # dirty hack to strip off trailing dot
+  domain      = trimsuffix(var.dns_zone, ".")
   statuses    = ["ISSUED"]
   most_recent = true
 }


### PR DESCRIPTION
## Changes
- Fixed suffix trimming to work on aws provider 2.x and 3.x on v2.1.0 code in use in runkeeper-terraform
